### PR TITLE
Changed NFS volume naming

### DIFF
--- a/app/templates/deployment.yaml
+++ b/app/templates/deployment.yaml
@@ -133,7 +133,7 @@ spec:
         {{- range .Values.additionalNfsPvc }}
         - name: {{ lower .name }}
           persistentVolumeClaim:
-            claimName: {{ $fullname }}-{{ lower .name }}-new
+            claimName: {{ $fullname }}-{{ lower .name }}
         {{- end }}
         {{- range .Values.additionalRamPvc }}
         - name: {{ lower .name }}


### PR DESCRIPTION
New volume name will be {{ $fullname }}-{{ lower .name }} instead of {{ $fullname }}-{{ lower .name }}-new (not compatible with https://github.com/kubernetes-sigs/nfs-ganesha-server-and-external-provisioner/tree/master)