### PR TITLE
fix_ImageUpdateAutomation_messageTemplate

### DIFF
--- a/app/Chart.yaml
+++ b/app/Chart.yaml
@@ -13,4 +13,4 @@ maintainers:
 #
 # NOTE: this value is set at build time. DO NOT CHANGE.
 #
-version: 1.3.13
+version: 1.3.14

--- a/app/templates/imageupdater.yaml
+++ b/app/templates/imageupdater.yaml
@@ -54,19 +54,20 @@ spec:
         Automation name: {{ .AutomationObject }}
 
         Files:
-        {{ range $filename, $_ := .Updated.Files -}}
+        {{ range $filename, $_ := .Changed.FileChanges -}}
         - {{ $filename }}
         {{ end -}}
 
         Objects:
-        {{ range $resource, $_ := .Updated.Objects -}}
+        {{ range $resource, $_ := .Changed.Objects -}}
         - {{ $resource.Kind }} {{ $resource.Name }}
         {{ end -}}
 
-        Images:
-        {{ range .Updated.Images -}}
-        - {{.}}
+        Updates:
+        {{ range .Changed.Changes -}}
+        - {{ .OldValue }} -> {{ .NewValue }}
         {{ end -}}
+
         [skip ci]`}}
     push:
       branch: main


### PR DESCRIPTION
Fix ImageUpdateAutomation messageTemplate to avoid the followinf error
`template uses removed '.Updated' field. Please use '.Changed' instead. `

https://fluxcd.io/flux/components/image/imageupdateautomations/#message-template
